### PR TITLE
Updated array-tools version due to breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tape": "^4"
   },
   "dependencies": {
-    "array-tools": "^1.1.4",
+    "array-tools": "^1.8.4",
     "typical": "^2.2"
   }
 }


### PR DESCRIPTION
In the `object-tools.js` file `array-tools` is used as follows: `var last = a(args).last();` which is invalid API for version `1.1.4`
